### PR TITLE
feat: allow importing without ESM interop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+declare namespace isUnicodeSupported { }
+
 /**
 Detect whether the terminal supports Unicode.
 


### PR DESCRIPTION
Adds a simple fix for v0.1.0 to allow it to be imported in TypeScript without the need of esModuleInterop or allowSyntheticDefaultImports

With this commit, the following syntax will start to work in TypeScript without the mentioned options

```ts
import * as isUnicodeSupported from 'is-unicode-supported';

const supportsUnicode = isUnicodeSupported();
```

#cenk1cenk2/listr2/pull/373