### PR TITLE
Fix tests on Windows

### DIFF
--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ test.serial('windows', t => {
 	delete process.env.CI;
 	delete process.env.TERM;
 	delete process.env.TERM_PROGRAM;
+	delete process.env.WT_SESSION;
 
 	const originalPlatform = process.platform;
 
@@ -18,5 +19,4 @@ test.serial('windows', t => {
 	t.true(isUnicodeSupported());
 
 	Object.defineProperty(process, 'platform', {value: originalPlatform});
-	delete process.env.WT_SESSION;
 });


### PR DESCRIPTION
As I prepared #1, my test failed. I realized it was because it detected my Windows Terminal session. This is a small fix that will allow windows users to contribute in the future.