### PR TITLE
Fix support for Linux console (kernel)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export default function isUnicodeSupported() {
 	if (process.platform !== 'win32') {
-		return true;
+		return process.env.TERM !== 'linux'; // Linux console (kernel)
 	}
 
 	return Boolean(process.env.CI) ||


### PR DESCRIPTION
The Linux kernel console has very poor support for Unicode symbols.
This PR fixes detecting it.