### PR TITLE
JetBrains terminal also supports unicode

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ export default function isUnicodeSupported() {
 		|| process.env.ConEmuTask === '{cmd::Cmder}' // ConEmu and cmder
 		|| process.env.TERM_PROGRAM === 'vscode'
 		|| process.env.TERM === 'xterm-256color'
-		|| process.env.TERM === 'alacritty';
+		|| process.env.TERM === 'alacritty'
+		|| process.env.TERMINAL_EMULATOR === 'JetBrains-JediTerm';
 }


### PR DESCRIPTION
JetBrains CLI for all JetBrains IDE uses this new env var. The JetBrains CLI does support Unicode! ;D