### PR TITLE
add support for Warp terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,5 +12,6 @@ export default function isUnicodeSupported() {
 		|| process.env.TERM_PROGRAM === 'vscode'
 		|| process.env.TERM === 'xterm-256color'
 		|| process.env.TERM === 'alacritty'
+		|| process.env.TERM === 'WarpTerminal'
 		|| process.env.TERMINAL_EMULATOR === 'JetBrains-JediTerm';
 }


### PR DESCRIPTION
[Warp](https://www.warp.dev/) is a relatively new terminal for macOS and Linux. Thought you might want to support it.